### PR TITLE
Symlink external data location

### DIFF
--- a/mantid-development/docker/CentOS7.Dockerfile
+++ b/mantid-development/docker/CentOS7.Dockerfile
@@ -52,6 +52,12 @@ VOLUME ["/mantid_src", "/mantid_build", "/mantid_data", "/ccache"]
 ADD abc_sudo_with_no_passwd \
     /etc/sudoers.d/abc_sudo_with_no_passwd
 
+# Add a symlink pointing the default external data location to the mapped
+# volume
+RUN ln -s \
+      /mantid_data \
+      /home/abc/MantidExternalData
+
 # Set default working directory to build directory
 WORKDIR /mantid_build
 

--- a/mantid-development/docker/UbuntuBionic.Dockerfile
+++ b/mantid-development/docker/UbuntuBionic.Dockerfile
@@ -79,6 +79,12 @@ VOLUME ["/mantid_src", "/mantid_build", "/mantid_data", "/ccache"]
 ADD abc_sudo_with_no_passwd \
     /etc/sudoers.d/abc_sudo_with_no_passwd
 
+# Add a symlink pointing the default external data location to the mapped
+# volume
+RUN ln -s \
+      /mantid_data \
+      /home/abc/MantidExternalData
+
 # Set default working directory to build directory
 WORKDIR /mantid_build
 

--- a/mantid-development/docker/UbuntuXenial.Dockerfile
+++ b/mantid-development/docker/UbuntuXenial.Dockerfile
@@ -75,6 +75,12 @@ VOLUME ["/mantid_src", "/mantid_build", "/mantid_data", "/ccache"]
 ADD abc_sudo_with_no_passwd \
     /etc/sudoers.d/abc_sudo_with_no_passwd
 
+# Add a symlink pointing the default external data location to the mapped
+# volume
+RUN ln -s \
+      /mantid_data \
+      /home/abc/MantidExternalData
+
 # Set default working directory to build directory
 WORKDIR /mantid_build
 

--- a/mantid-development/readme.md
+++ b/mantid-development/readme.md
@@ -25,8 +25,11 @@ build ParaView.
 
 The images contain three directories `/mantid_src`, `/mantid_build` and
 `/mantid_data` which are to be used for the source, build and CMake external
-data directories respectively. It is recommended to have these directories
-mounted to locations on the host filesystem. Reasons being:
+data directories respectively. `/mantid_data` is the target of a symbolic link
+from the default external data location configured in CMake.
+
+It is recommended to have these directories mounted to locations on the host
+filesystem. Reasons being:
 
 - Using your existing SCM, editors, etc. (you modify the code on the host
   filesystem as you will have probably already been doing)
@@ -68,7 +71,6 @@ cmake \
   -DMAKE_VATES=ON \
   -DParaView_DIR=/paraview/build/ParaView-5.4.1/ \
   -DENABLE_WORKBENCH=ON \
-  -DMANTID_DATA_STORE=/mantid_data/ \
   /mantid_src
 ```
 


### PR DESCRIPTION
Create a symbolic link from the default external data location (as the `abc` user) to the `/mantid_data` volume.

To test:
- Invoke contains using both named Docker volumes and host filesystem mapping for the `/mantid_data` volume
- See that container start up time is not largely affected
- See that external data still works (just running the download test data jobs is probably enough)

(I won't publish test images for this PR as only the last layer changes so having already downloaded the latest development images means the build time will be very short)