### PR TITLE
Correctly preserve environment in entrypoint.sh

### DIFF
--- a/mantid-development/docker/entrypoint.sh
+++ b/mantid-development/docker/entrypoint.sh
@@ -24,4 +24,7 @@ chown ${TARGET_USERNAME}:${TARGET_USERNAME} /ccache
 
 # Run the supplied command as the target user
 CMD=${@:-"bash"}
-runuser --command="${CMD}" - ${TARGET_USERNAME}
+# This form of runuser is used as it only sets the environment variables
+# required to change the user, preserving all others that are set (see man
+# runuser).
+runuser -u ${TARGET_USERNAME} -- ${CMD}


### PR DESCRIPTION
See commit message for description.

cc @martyngigg @marshallmcdonnell

@marshallmcdonnell, this will mean that you can no longer chain commands using `&`, however that is easy to do using a script (either copied or mounted to the container) and reverting the last change to `entrypoint.sh` was the easiest fix without having to add additional environment injection.