### PR TITLE
Add Xvfb to docker images

### DIFF
--- a/mantid-development/docker/CentOS7.Dockerfile
+++ b/mantid-development/docker/CentOS7.Dockerfile
@@ -17,6 +17,9 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     # Install ccache
     yum install -y \
       ccache && \
+    # Install xvfb
+    yum install -y \
+      xorg-x11-server-Xvfb && \
     # Install static analysis dependencies
     pip install \
       flake8==2.5.4 \

--- a/mantid-development/docker/UbuntuBionic.Dockerfile
+++ b/mantid-development/docker/UbuntuBionic.Dockerfile
@@ -41,6 +41,9 @@ RUN apt-get update && \
       ipython3-qtconsole \
       python3-h5py \
       python3-yaml && \
+    # Install xvfb
+    apt-get install -y \
+      xvfb && \
     # Install static analysis dependencies
     pip install \
       flake8==2.5.4 \

--- a/mantid-development/docker/UbuntuXenial.Dockerfile
+++ b/mantid-development/docker/UbuntuXenial.Dockerfile
@@ -37,6 +37,9 @@ RUN apt-get update && \
       ipython3-qtconsole \
       python3-h5py \
       python3-yaml && \
+    # Install xvfb
+    apt-get install -y \
+      xvfb && \
     # Install static analysis dependencies
     pip install \
       flake8==2.5.4 \

--- a/mantid-jenkins-nodes/docker/UbuntuBionic.Dockerfile
+++ b/mantid-jenkins-nodes/docker/UbuntuBionic.Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
       gdebi-core \
-      openjdk-8-jdk \
-      xvfb && \
+      openjdk-8-jdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/mantid-jenkins-nodes/docker/UbuntuXenial.Dockerfile
+++ b/mantid-jenkins-nodes/docker/UbuntuXenial.Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
       gdebi-core \
-      openjdk-8-jdk \
-      xvfb && \
+      openjdk-8-jdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Makes `xvfb-run` available to the docker images. I've found it useful to use this as it's easier than install x11docker and more closely matches what runs on the builders.