### PR TITLE
Update docker start script to use --init=none

### DIFF
--- a/mantid-development/bin/mantid_development_x11docker.sh
+++ b/mantid-development/bin/mantid_development_x11docker.sh
@@ -13,7 +13,7 @@ x11docker \
   --hostipc \
   --hostdisplay \
   --cap-default \
-  --no-init \
+  --init=none \
   --user=RETAIN \
   -- "--volume $SOURCE_DIR:/mantid_src --volume $BUILD_DIR:/mantid_build --volume $DATA_DIR:/mantid_data --env PUID=$PUID --env PGID=$PGID" \
   "mantidproject/mantid-development-$OS:latest" \


### PR DESCRIPTION
`--no-init` was removed from `x11docker` at some point recently: https://github.com/mviereck/x11docker/wiki/Init-systems#no-init-system. This change ensures our script functions with the latest version.
