### PR TITLE
Add psmisc package to jenkins-node image

### DIFF
--- a/jenkins-node/docker/UbuntuBionic.Dockerfile
+++ b/jenkins-node/docker/UbuntuBionic.Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
       gdebi-core \
-      openjdk-8-jdk && \
+      openjdk-8-jdk \
+      psmisc && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/jenkins-node/docker/UbuntuXenial.Dockerfile
+++ b/jenkins-node/docker/UbuntuXenial.Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
       gdebi-core \
-      openjdk-8-jdk && \
+      openjdk-8-jdk \
+      psmisc && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Required by mantid build scripts to provide `killall` command.