### PR TITLE
Install clang-format-6 into development image

### DIFF
--- a/development/docker/UbuntuBionic.Dockerfile
+++ b/development/docker/UbuntuBionic.Dockerfile
@@ -81,6 +81,14 @@ RUN git clone https://github.com/mantidproject/paraview-build.git /tmp/paraview 
     # Clean up
     rm -rf /tmp/* /var/tmp/*
 
+# Install clang-format-6
+RUN apt-get update && \
+    apt-get install -y \
+      clang-format-6.0 && \
+    # Clean up
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Set ccache cache location
 ENV CCACHE_DIR /ccache
 


### PR DESCRIPTION
It will soon become a requirement for mantid
developement and this is needed to ensure builds
can pass while moving between 5 & 6.