### PR TITLE
Remove ParaView builds against Python 2 

### DIFF
--- a/development/docker/CentOS7.Dockerfile
+++ b/development/docker/CentOS7.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /mantid_src && \
 # Build ParaView
 RUN git clone https://github.com/mantidproject/paraview-build.git /tmp/paraview && \
     git --git-dir=/tmp/paraview/.git --work-tree=/tmp/paraview checkout ${PARAVIEW_BUILD_REVISION} && \
-    env HOME=/paraview BUILD_THREADS=`nproc` NODE_LABELS=centos7 /tmp/paraview/buildscript && \
+    env HOME=/paraview BUILD_THREADS=`nproc` NODE_LABELS=centos7 JOB_NAME=python3 /tmp/paraview/buildscript && \
     # Give world RW access to ParaView
     chmod -R o+rw /paraview && \
     # Clean up

--- a/development/docker/UbuntuBionic.Dockerfile
+++ b/development/docker/UbuntuBionic.Dockerfile
@@ -60,14 +60,6 @@ RUN git clone https://github.com/mantidproject/paraview-build.git /tmp/paraview 
     # Clean up
     rm -rf /tmp/* /var/tmp/*
 
-# Install clang-format-6
-RUN apt-get update && \
-    apt-get install -y \
-      clang-format-6.0 && \
-    # Clean up
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 # Set ccache cache location
 ENV CCACHE_DIR /ccache
 

--- a/development/docker/UbuntuBionic.Dockerfile
+++ b/development/docker/UbuntuBionic.Dockerfile
@@ -53,7 +53,6 @@ RUN mkdir -p /mantid_src && \
 # Build ParaView
 RUN git clone https://github.com/mantidproject/paraview-build.git /tmp/paraview && \
     git -C /tmp/paraview checkout ${PARAVIEW_BUILD_REVISION} && \
-    env HOME=/paraview BUILD_THREADS=`nproc` NODE_LABELS=ubuntu /tmp/paraview/buildscript && \
     env HOME=/paraview BUILD_THREADS=`nproc` NODE_LABELS=ubuntu JOB_NAME=python3 /tmp/paraview/buildscript && \
     # Give world RW access to ParaView
     chmod -R o+rw /paraview && \

--- a/development/docker/build.sh
+++ b/development/docker/build.sh
@@ -31,5 +31,5 @@ function build_image {
 
 mkdir -p ${BUILD_LOG_DIR}
 
-build_image CentOS7.Dockerfile centos7 "1.35"
-build_image UbuntuBionic.Dockerfile ubuntubionic "1.4.1"
+build_image CentOS7.Dockerfile centos7 "2.0"
+build_image UbuntuBionic.Dockerfile ubuntubionic "2.0"


### PR DESCRIPTION
Removes Python 2 builds of ParaView from the development images and bumps the developer package version to use the Python 3-only versions.