### PR TITLE
Add GNU parallel to static analysis image

### DIFF
--- a/jenkins-node/docker-images/static-analysis/Dockerfile
+++ b/jenkins-node/docker-images/static-analysis/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update
 RUN apt-get install -t stretch-backports cmake -y --no-install-recommends
 
 # Ordered in probability of each updating from least->most
-RUN apt-get install clang-format-6.0 -y --no-install-recommends
+RUN apt-get install clang-format-6.0 parallel -y --no-install-recommends
 RUN apt-get install cmake -y --no-install-recommends
 RUN apt-get install doxygen -y --no-install-recommends
 RUN apt-get install python3 python3-pip -y --no-install-recommends


### PR DESCRIPTION
Adds GNU parallel to static analysis image, this means we can move some of our single threaded jobs (clang-format) to automatically be parallel.

`xargs` has a `-P` flag but this `parallel` can auto scale based on the builders number of cores.