### PR TITLE
Drop Cppcheck 1.90

### DIFF
--- a/jenkins-node/docker-images/static-analysis/Dockerfile
+++ b/jenkins-node/docker-images/static-analysis/Dockerfile
@@ -4,8 +4,8 @@
 
 FROM alpine:latest AS cppcheck_build
 
-# Version 1.90
-ARG cppcheck_commit=077e652
+# Version 1.82
+ARG cppcheck_commit=23b253e9eb3296a03afd5d52908726da1231f0dd
 
 RUN apk add git ninja cmake g++ pcre-dev && \
     git clone https://github.com/danmar/cppcheck.git


### PR DESCRIPTION
Drops cppcheck 1.90 since the work in Mantid is taking longer than
expected. This is currently blocking our Python 3 migration.