### PR TITLE
Adds watchtower to deploy scripts

### DIFF
--- a/jenkins-node/bin/deploy_container_host.sh
+++ b/jenkins-node/bin/deploy_container_host.sh
@@ -37,6 +37,13 @@ then
   docker container rm "$EXISTING_CONTAINER_ID"
 fi
 
+WATCHTOWER_ID=`docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    containrrr/watchtower`
+
+echo "Started Watchtower: $WATCHTOWER_ID"
+
 # Start a new container
 echo '=== Starting new container'
 NEW_CONTAINER_ID=`docker run \

--- a/jenkins-node/bin/deploy_netdata.sh
+++ b/jenkins-node/bin/deploy_netdata.sh
@@ -28,11 +28,20 @@ fi
 
 netdata_conf="$PWD/netdata"
 
+WATCHTOWER_ID=`docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    containrrr/watchtower`
+
+echo "Started Watchtower: $WATCHTOWER_ID"
+
 # Write the alert config script
 alarm_config_file="$netdata_conf/health_alarm_notify.conf"
 echo 'SEND_SLACK="YES"' > "$alarm_config_file"
 echo 'DEFAULT_RECIPIENT_SLACK="#jenkins-admins"' >> "$alarm_config_file"
 echo "SLACK_WEBHOOK_URL=\"https://hooks.slack.com/services/$1\"" >> "$alarm_config_file"
+
+
 
 # Start a new container
 echo '=== Starting new container'

--- a/jenkins-node/bin/deploy_static_analysis.sh
+++ b/jenkins-node/bin/deploy_static_analysis.sh
@@ -37,6 +37,13 @@ then
   docker container rm "$EXISTING_CONTAINER_ID"
 fi
 
+WATCHTOWER_ID=`docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    containrrr/watchtower`
+
+echo "Started Watchtower: $WATCHTOWER_ID"
+
 # Start a new container
 echo '=== Starting new container'
 NEW_CONTAINER_ID=`docker run \

--- a/jenkins-node/readme.md
+++ b/jenkins-node/readme.md
@@ -69,6 +69,8 @@ ssh_authorized_keys:
 ## Maintenance
 
 - RancherOS mostly takes care of itself.
+- Watchtower will automatically deploy any updated images pushed upstream that use the same tag.
+  So if your prototyping/testing check your pushing to a local repo and not the Mantid docker.
 - An occasional `docker system prune` will remove unsued Docker objects that hog disk space.
 - You can monitor the systen via Netdata at `http://[hostname]:19999`.
   Useful things this can tell you include:


### PR DESCRIPTION
Adds watchtower to restart our docker images if a new one is pushed
upstream. 

This doesn't help with our OS builders currently (as each uses
a different tag so watchtower can't see the new tag). However, our
static-analysis node and netdata will benefit from this.