### PR TITLE
Use Jenkins node as base image for static analysis

### DIFF
--- a/jenkins-node/docker-images/static-analysis/Dockerfile
+++ b/jenkins-node/docker-images/static-analysis/Dockerfile
@@ -18,27 +18,23 @@ RUN CXXFLAGS="--static" cmake .. -DCMAKE_BUILD_TYPE=Release -DHAVE_RULES=ON \
     -DUSE_MATCHCOMPILER=ON -G Ninja && \
     cmake --build .
 
-FROM jenkins/jnlp-slave
+FROM mantidproject/jenkins-node:ubuntubionic
 
 ARG FLAKE_VERSION=3.7.9
 ARG PEP_VERSION=1.7.1
 
-COPY --from=cppcheck_build /cppcheck/build/bin/cppcheck /usr/bin/
-COPY --from=cppcheck_build /cppcheck/cfg /usr/local/share/Cppcheck/cfg
+COPY --from=cppcheck_build /cppcheck/build/bin/cppcheck /usr/local/bin/
+COPY --from=cppcheck_build /cppcheck/cfg /usr/local/share/CppCheck
 
-USER root
-
-RUN apt-get update
-RUN apt-get install -t stretch-backports cmake -y --no-install-recommends
-
-# Ordered in probability of each updating from least->most
-RUN apt-get install clang-format-6.0 parallel -y --no-install-recommends
-RUN apt-get install cmake -y --no-install-recommends
-RUN apt-get install doxygen -y --no-install-recommends
-RUN apt-get install python3 python3-pip -y --no-install-recommends
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    clang-format-6.0 \
+    doxygen \
+    parallel \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \
     flake8==${FLAKE_VERSION} \
     pep8==${PEP_VERSION}
-
-USER jenkins


### PR DESCRIPTION
Sets the static analysis image to use the Jenkins node as a base pulling in our deps. This is because cmake has required finds which must complete first