### PR TITLE
Increase available shared memory in dev container

### DIFF
--- a/development/bin/mantid_development.sh
+++ b/development/bin/mantid_development.sh
@@ -12,6 +12,7 @@ docker run \
   --tty \
   --env PUID=`id -u` \
   --env PGID=`id -g` \
+  --shm-size=512m \
   --volume "$SOURCE_DIR:/mantid_src" \
   --volume "$BUILD_DIR:/mantid_build" \
   --volume "$DATA_DIR:/mantid_data" \


### PR DESCRIPTION
**Description**

Increases the available shared memory in development container when started with the `mantid_development.sh` script. The `LoadEventNexusTest` tests multi-process loading and requires more than the 64m of shared memory available that Docker makes available by default.

**Testing**

* Start a CentOS 7 development container and build `DataHandlingTest`
* Run the `LoadEventNexusTest` and it should pass. Before this it failed with a bus error.