### PR TITLE
Fix "D-Bus library appears to be incorrectly set up;" error

### DIFF
--- a/development/docker/CentOS7.Dockerfile
+++ b/development/docker/CentOS7.Dockerfile
@@ -60,6 +60,9 @@ ADD configure/centos7.sh \
     /home/abc/configure.sh
 RUN chown abc:abc /home/abc/configure.sh
 
+# Fixes "D-Bus library appears to be incorrectly set up;" error
+RUN dbus-uuidgen > /var/lib/dbus/machine-id
+
 ADD entrypoint.sh /entrypoint.sh
 ADD entrypoint.d/ /etc/entrypoint.d/
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
We are trying to use the CentOS7 docker image `mantidproject/jenkins-node:centos7` for our build servers and when [running the tests a lot fail with the message](https://builds.mantidproject.org/job/pull_requests-rhel7/37440/console)

```
libEGL warning: DRI2: failed to open swrast (search paths /usr/lib64/dri)
D-Bus library appears to be incorrectly set up; failed to read machine uuid: UUID file '/etc/machine-id' should contain a hex string of length 32, not length 0, with no other text
See the manual page for dbus-uuidgen to correct this issue.
```

This can happen when xorg is installed on a barebones system (like docker) as things don't get set up correctly.

This should fix that.