### PR TITLE
Add netdata filters to remove noise

### DIFF
--- a/jenkins-node/bin/deploy_netdata.sh
+++ b/jenkins-node/bin/deploy_netdata.sh
@@ -26,7 +26,9 @@ then
   docker container rm "$EXISTING_CONTAINER_ID"
 fi
 
-netdata_conf="$PWD/netdata"
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PARENT_DIR="$THIS_DIR/.."
+NET_DATA_DIR="$PARENT_DIR/netdata"
 
 WATCHTOWER_ID=`docker run -d \
     --name watchtower \
@@ -36,7 +38,7 @@ WATCHTOWER_ID=`docker run -d \
 echo "Started Watchtower: $WATCHTOWER_ID"
 
 # Write the alert config script
-alarm_config_file="$netdata_conf/health_alarm_notify.conf"
+alarm_config_file="$NET_DATA_DIR/health_alarm_notify.conf"
 echo 'SEND_SLACK="YES"' > "$alarm_config_file"
 echo 'DEFAULT_RECIPIENT_SLACK="#jenkins-admins"' >> "$alarm_config_file"
 echo "SLACK_WEBHOOK_URL=\"https://hooks.slack.com/services/$1\"" >> "$alarm_config_file"
@@ -52,7 +54,7 @@ docker run \
   --restart=always \
   --net=host \
   --volume "$alarm_config_file":/etc/netdata/health_alarm_notify.conf:ro \
-  --volume "$netdata_conf/health.d":/etc/netdata/health.d:ro \
+  --volume "$NET_DATA_DIR/health.d":/etc/netdata/health.d:ro \
   --volume /etc/passwd:/host/etc/passwd:ro \
   --volume /etc/group:/host/etc/group:ro \
   --volume /proc:/host/proc:ro \

--- a/jenkins-node/bin/deploy_netdata.sh
+++ b/jenkins-node/bin/deploy_netdata.sh
@@ -30,19 +30,11 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 PARENT_DIR="$THIS_DIR/.."
 NET_DATA_DIR="$PARENT_DIR/netdata"
 
-WATCHTOWER_ID=`docker run -d \
-    --name watchtower \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    containrrr/watchtower`
-
-echo "Started Watchtower: $WATCHTOWER_ID"
-
 # Write the alert config script
 alarm_config_file="$NET_DATA_DIR/health_alarm_notify.conf"
 echo 'SEND_SLACK="YES"' > "$alarm_config_file"
 echo 'DEFAULT_RECIPIENT_SLACK="#jenkins-admins"' >> "$alarm_config_file"
 echo "SLACK_WEBHOOK_URL=\"https://hooks.slack.com/services/$1\"" >> "$alarm_config_file"
-
 
 
 # Start a new container

--- a/jenkins-node/netdata/health.d/cpu.conf
+++ b/jenkins-node/netdata/health.d/cpu.conf
@@ -1,3 +1,19 @@
+
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+template: 10min_cpu_usage
+      on: system.cpu
+      os: linux
+   hosts: *
+  lookup: average -10m unaligned of user,system,softirq,irq,guest
+   units: %
+   every: 1m
+    warn: $this > (($status >= $WARNING)  ? (75) : (85))
+    crit: $this > (($status == $CRITICAL) ? (85) : (95))
+   delay: down 15m multiplier 1.5 max 1h
+    info: average cpu utilization for the last 10 minutes (excluding iowait, nice and steal)
+      to: silent
+
 template: 10min_cpu_iowait
       on: system.cpu
       os: linux
@@ -22,18 +38,4 @@ template: 20min_steal_cpu
     crit: $this > (($status == $CRITICAL) ? (20) : (30))
    delay: down 1h multiplier 1.5 max 2h
     info: average CPU steal time for the last 20 minutes
-      to: sysadmin
-
-## FreeBSD
-template: 10min_cpu_usage
-      on: system.cpu
-      os: freebsd
-   hosts: *
-  lookup: average -10m unaligned of user,system,interrupt
-   units: %
-   every: 1m
-    warn: $this > (($status >= $WARNING)  ? (75) : (85))
-    crit: $this > (($status == $CRITICAL) ? (85) : (95))
-   delay: down 15m multiplier 1.5 max 1h
-    info: average cpu utilization for the last 10 minutes (excluding nice)
       to: sysadmin

--- a/jenkins-node/netdata/health.d/net.conf
+++ b/jenkins-node/netdata/health.d/net.conf
@@ -1,0 +1,167 @@
+
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# -----------------------------------------------------------------------------
+# net traffic overflow
+
+ template: interface_speed
+       on: net.net
+       os: *
+    hosts: *
+ families: *
+     calc: ( $nic_speed_max > 0 ) ? ( $nic_speed_max) : ( nan )
+    units: Mbit
+    every: 10s
+     info: The current speed of the physical network interface
+
+ template: 1m_received_traffic_overflow
+       on: net.net
+       os: linux
+    hosts: *
+ families: *
+   lookup: average -1m unaligned absolute of received
+     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
+    units: %
+    every: 10s
+     warn: $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (90))
+    delay: down 1m multiplier 1.5 max 1h
+     info: interface received bandwidth usage over net device speed max
+       to: sysadmin
+
+ template: 1m_sent_traffic_overflow
+       on: net.net
+       os: linux
+    hosts: *
+ families: *
+   lookup: average -1m unaligned absolute of sent
+     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
+    units: %
+    every: 10s
+     warn: $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (90))
+    delay: down 1m multiplier 1.5 max 1h
+     info: interface sent bandwidth usage over net device speed max
+       to: sysadmin
+
+# -----------------------------------------------------------------------------
+# dropped packets
+
+# check if an interface is dropping packets
+# the alarm is checked every 1 minute
+# and examines the last 10 minutes of data
+#
+# it is possible to have expected packet drops on an interface for some network configurations
+# look at the Monitoring Network Interfaces section in the proc.plugin documentation for more information
+
+template: inbound_packets_dropped
+      on: net.drops
+      os: linux
+   hosts: *
+families: *
+  lookup: sum -10m unaligned absolute of inbound
+   units: packets
+   every: 1m
+    warn: $this >= 100
+   delay: down 1h multiplier 1.5 max 2h
+    info: interface inbound dropped packets in the last 10 minutes
+      to: silent
+
+template: outbound_packets_dropped
+      on: net.drops
+      os: linux
+   hosts: *
+families: *
+  lookup: sum -10m unaligned absolute of outbound
+   units: packets
+   every: 1m
+    warn: $this >= 100
+   delay: down 1h multiplier 1.5 max 2h
+    info: interface outbound dropped packets in the last 10 minutes
+      to: silent
+
+template: inbound_packets_dropped_ratio
+      on: net.packets
+      os: linux
+   hosts: *
+families: *
+  lookup: sum -10m unaligned absolute of received
+    calc: (($inbound_packets_dropped != nan AND $this > 0) ? ($inbound_packets_dropped * 100 / $this) : (0))
+   units: %
+   every: 1m
+    warn: $this >= 10
+    crit: $this >= 20
+   delay: down 1h multiplier 1.5 max 2h
+    info: the ratio of inbound dropped packets vs the total number of received packets of the network interface, during the last 10 minutes
+      to: sysadmin
+
+template: outbound_packets_dropped_ratio
+      on: net.packets
+      os: linux
+   hosts: *
+families: *
+  lookup: sum -10m unaligned absolute of sent
+    calc: (($outbound_packets_dropped != nan AND $this > 0) ? ($outbound_packets_dropped * 100 / $this) : (0))
+   units: %
+   every: 1m
+    warn: $this >= 10
+    crit: $this >= 20
+   delay: down 1h multiplier 1.5 max 2h
+    info: the ratio of outbound dropped packets vs the total number of sent packets of the network interface, during the last 10 minutes
+      to: sysadmin
+
+
+# -----------------------------------------------------------------------------
+# FIFO errors
+
+# check if an interface is having FIFO
+# buffer errors
+# the alarm is checked every 1 minute
+# and examines the last 10 minutes of data
+
+template: 10min_fifo_errors
+      on: net.fifo
+      os: linux
+   hosts: *
+families: *
+  lookup: sum -10m unaligned absolute
+   units: errors
+   every: 1m
+    warn: $this > 0
+   delay: down 1h multiplier 1.5 max 2h
+    info: interface fifo errors in the last 10 minutes
+      to: sysadmin
+
+# -----------------------------------------------------------------------------
+# check for packet storms
+
+# 1. calculate the rate packets are received in 1m: 1m_received_packets_rate
+# 2. do the same for the last 10s
+# 3. raise an alarm if the later is 10x or 20x the first
+# we assume the minimum packet storm should at least have
+# 10000 packets/s, average of the last 10 seconds
+
+template: 1m_received_packets_rate
+      on: net.packets
+      os: linux freebsd
+   hosts: *
+families: *
+  lookup: average -1m unaligned of received
+   units: packets
+   every: 10s
+    info: the average number of packets received during the last minute
+
+template: 10s_received_packets_storm
+      on: net.packets
+      os: linux freebsd
+   hosts: *
+families: *
+  lookup: average -10s unaligned of received
+    calc: $this * 100 / (($1m_received_packets_rate < 1000)?(1000):($1m_received_packets_rate))
+   every: 10s
+   units: %
+    warn: $this > (($status >= $WARNING)?(200):(5000))
+    crit: $this > (($status >= $WARNING)?(5000):(6000))
+ options: no-clear-notification
+    info: the % of the rate of received packets in the last 10 seconds, compared to the rate of the last minute (clear notification for this alarm will not be sent)
+      to: sysadmin

--- a/jenkins-node/netdata/health.d/ram.conf
+++ b/jenkins-node/netdata/health.d/ram.conf
@@ -1,0 +1,37 @@
+
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+   alarm: used_ram_to_ignore
+      on: system.ram
+      os: linux freebsd
+   hosts: *
+    calc: ($zfs.arc_size.arcsz = nan)?(0):($zfs.arc_size.arcsz - $zfs.arc_size.min)
+   every: 10s
+    info: the amount of memory that is reported as used, but it is actually capable for resizing itself based on the system needs (eg. ZFS ARC)
+
+   alarm: ram_in_use
+      on: system.ram
+      os: linux
+   hosts: *
+#   calc: $used * 100 / ($used + $cached + $free)
+    calc: ($used - $used_ram_to_ignore) * 100 / ($used  + $cached + $free)
+   units: %
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? (90) : (93))
+    crit: $this > (($status == $CRITICAL) ? (93) : (98))
+   delay: down 15m multiplier 1.5 max 1h
+    info: system RAM used
+      to: sysadmin
+
+   alarm: ram_available
+      on: mem.available
+      os: linux
+   hosts: *
+    calc: ($avail + $system.ram.used_ram_to_ignore) * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
+   units: %
+   every: 10s
+    warn: $this < (($status >= $WARNING)  ? (10) : (5))
+    crit: $this < (($status == $CRITICAL) ? (5) : (2))
+   delay: down 15m multiplier 1.5 max 1h
+    info: estimated amount of RAM available for userspace processes, without causing swapping
+      to: sysadmin

--- a/mantid/README.md
+++ b/mantid/README.md
@@ -38,6 +38,24 @@ x11docker \
 
 You will more than likely want to assign some volumes to access data too.
 
+## Rancher OS
+
+If your deploying to Rancher OS use the following alias to use git:
+
+```sh
+alias git="docker run -ti --rm -v $(pwd):/git alpine/git"
+```
+
+After doing a git clone you will need to re-run the alias to update the working dir:
+
+```sh
+alias git="docker run -ti --rm -v $(pwd):/git alpine/git"
+git clone https://github.com/mantidproject/dockerfiles.git
+alias git="docker run -ti --rm -v $(pwd):/git alpine/git"
+git status
+```
+
+
 ## Tags/versions
 
 The following tags are available:


### PR DESCRIPTION
Hopefully this becomes more useful for Disk errors / OOM kill ....etc.

The primary changes are:
- Fix pwd relying on us being in the actual dir
- Bump OOM to 90%+
- Remove high CPU warnings
- Remove dropped packet warnings unless they get to >10%

I've deployed this as a trial on ndw902/903 as they regularly spam #jenkins-admin with packets dropped, so we can have a look after the weekend