### PR TITLE
Add link to WSL2 setup instructions

### DIFF
--- a/development/readme.md
+++ b/development/readme.md
@@ -1,6 +1,6 @@
 # Mantid development environment in Docker
 
-Docker container for building, testing and developing Mantid.
+Docker container for building, testing and developing Mantid. If your host system is Windows then it might be better to setup a [Windows Subsystem for Linux (WSL2)](https://developer.mantidproject.org/WindowsSubsystemForLinux.html).
 
 ## Base images and versions
 


### PR DESCRIPTION
This PR adds a link to the WSL2 setup instructions to the readme. This is useful if your host system is Windows.