### PR TITLE
Add cppcheck-htmlreport tool to static-analysis image

### DIFF
--- a/jenkins-node/docker-images/static-analysis/Dockerfile
+++ b/jenkins-node/docker-images/static-analysis/Dockerfile
@@ -25,6 +25,7 @@ ARG PEP_VERSION=1.7.1
 
 COPY --from=cppcheck_build /cppcheck/build/bin/cppcheck /usr/local/bin/
 COPY --from=cppcheck_build /cppcheck/cfg /usr/local/share/CppCheck
+COPY --from=cppcheck_build /cppcheck/htmlreport /tmp/cppcheck-htmlreport
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -38,3 +39,5 @@ RUN apt-get update && \
 RUN pip3 install \
     flake8==${FLAKE_VERSION} \
     pep8==${PEP_VERSION}
+
+RUN cd /tmp/cppcheck-htmlreport && python3 setup.py install


### PR DESCRIPTION
The Jenkins CppCheck plugin contains a bug when the build is run on a child node causing the links to files in the report to fail:

![Screenshot 2021-07-29 at 08 18 02](https://user-images.githubusercontent.com/733773/127448775-05553e6a-dbfd-48de-84e7-b78496f79019.png)

The tool installed here is provided by cppcheck & provides an alternate mechanism to generate a report that is more useful for developers.