### PR TITLE
Cppcheck 2.5

### DIFF
--- a/jenkins-node/docker-images/static-analysis/Dockerfile
+++ b/jenkins-node/docker-images/static-analysis/Dockerfile
@@ -4,8 +4,8 @@
 
 FROM alpine:latest AS cppcheck_build
 
-# Version 1.82
-ARG cppcheck_commit=23b253e9eb3296a03afd5d52908726da1231f0dd
+# Version 2.5
+ARG cppcheck_commit=f5b44b0b0b59d6d3284357e08884ad8c59612599
 
 RUN apk add git ninja cmake g++ pcre-dev && \
     git clone https://github.com/danmar/cppcheck.git

--- a/jenkins-node/docker-images/static-analysis/Dockerfile
+++ b/jenkins-node/docker-images/static-analysis/Dockerfile
@@ -24,7 +24,7 @@ ARG FLAKE_VERSION=3.7.9
 ARG PEP_VERSION=1.7.1
 
 COPY --from=cppcheck_build /cppcheck/build/bin/cppcheck /usr/local/bin/
-COPY --from=cppcheck_build /cppcheck/cfg /usr/local/share/CppCheck
+COPY --from=cppcheck_build /cppcheck/cfg /usr/local/share/Cppcheck/cfg
 COPY --from=cppcheck_build /cppcheck/htmlreport /tmp/cppcheck-htmlreport
 
 RUN apt-get update && \


### PR DESCRIPTION
At some point between 1.x and 2.x the path moved from /usr/local/share/CppCheck to /usr/local/share/Cppcheck/cfg (note the case in cppcheck too)
