### PR TITLE
Add clang tidy 12 to development image

### DIFF
--- a/development/docker/UbuntuBionic.Dockerfile
+++ b/development/docker/UbuntuBionic.Dockerfile
@@ -36,6 +36,11 @@ RUN apt-get update && \
     wget -O - http://apt.isis.rl.ac.uk/2E10C193726B7213.asc 2>/dev/null | apt-key add - && \
     apt-add-repository -y "deb [arch=amd64] http://apt.isis.rl.ac.uk $(lsb_release -c | cut -f 2) main" && \
     apt-add-repository -y ppa:mantid/mantid && \
+    # Add LLVM repository
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null| apt-key add - && \
+    echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-13 main" | tee /etc/apt/sources.list.d/clang-13.list && \
+    apt-get update && apt-get install -y clang-tidy-13 && \
+
     # Install the Mantid developer package
     apt-get update && \
     wget -O /tmp/mantid-developer.deb https://downloads.sourceforge.net/project/mantid/developer/mantid-developer_${DEV_PACKAGE_VERSION}_all.deb && \

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -10,10 +10,6 @@ cd $ROOT_DIR/development/docker/
 ./build.sh
 
 # Build jenkins-node using previous images
-cd $ROOT_DIR/jenkins-node/docker-images/os-builder/
-./build.sh
-
-# Build static analysis images
-cd $ROOT_DIR/jenkins-node/docker-images/static-analysis/
+cd $ROOT_DIR/jenkins-node/docker-images/
 ./build.sh
 


### PR DESCRIPTION
Note: This may hang on apt-add key stage on the VPN, seems like it's erroneously blocking / timing out on the http key protocol connection 