### PR TITLE
Add missing cleanup flag to watchtower

### DIFF
--- a/jenkins-node/bin/deploy_container_host.sh
+++ b/jenkins-node/bin/deploy_container_host.sh
@@ -40,7 +40,7 @@ fi
 WATCHTOWER_ID=`docker run -d \
     --name watchtower \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    containrrr/watchtower`
+    containrrr/watchtower --cleanup`
 
 echo "Started Watchtower: $WATCHTOWER_ID"
 


### PR DESCRIPTION
Watchtower was correctly deploying new images, but not removing the
older layers. This quickly was causing ORNL builders to run out of space
during periods of rapid change.

Add the missing flag to ensure this cleans up properly

To test:
- Copy command as-is and run from terminal (the new lines and escapes should work correctly)
- `docker ps` to verify watchtower is up