### PR TITLE
Patched Open SSL security vulnerability

### DIFF
--- a/development/docker/install_openssl.sh
+++ b/development/docker/install_openssl.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+#Install OpenSSL
+mkdir -p /OpenSSL
+cd /OpenSSL
+wget https://www.openssl.org/source/openssl-1.1.1t.tar.gz --no-check-certificate
+zcat openssl-1.1.1t.tar.gz | tar xf -
+cd openssl-1.1.1t
+./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared
+make
+make install


### PR DESCRIPTION
OpenSSL now has to be manually installed as we need to use v1.1.1t to patch a security vulnerability. Only the unpatched v1.0.2 is available to download on CentOS7. 

The other changes made as part of this work have accidentally been committed direct to the main branch in commit 87f1adc