### PR TITLE
Cleaned up Centos7Slim docker image

### DIFF
--- a/Linux/development/docker/CentOS7Slim.Dockerfile
+++ b/Linux/development/docker/CentOS7Slim.Dockerfile
@@ -1,14 +1,3 @@
-# Arguments allowed to be used in FROM have to come
-# before the first stage
-ARG CPPCHECK_VERSION=2.5
-
-# Import cppcheck. COPY --from cannot used variables.
-# Define a local name
-FROM neszt/cppcheck-docker:${CPPCHECK_VERSION} AS upstream_cppcheck
-
-#Add label for transparency
-LABEL org.opencontainers.image.source https://github.com/mantidproject/dockerfiles
-
 # Base
 # CentOS 7 matches platform used by conda-forge
 FROM centos:7
@@ -18,13 +7,15 @@ FROM centos:7
 RUN yum install -y \
   https://repo.ius.io/ius-release-el7.rpm && \
   yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+#Add label for transparency
+LABEL org.opencontainers.image.source https://github.com/mantidproject/dockerfiles
  
 # Add target user
 RUN useradd --uid 911 --user-group --shell /bin/bash --create-home abc
 
 # Install minimal developer tools
 RUN yum install -y \
-  ccache \
   curl \
   gcc \
   git236 \
@@ -40,7 +31,6 @@ RUN yum install -y \
   # Clean up
   rm -rf /tmp/* /var/tmp/* 
 
-  
 # Install patched version of OpenSSL (v1.1.1t)
 COPY ./install_openssl.sh /tmp/
 RUN bash /tmp/install_openssl.sh && \
@@ -51,33 +41,21 @@ COPY ./install_latex.sh /tmp/
 RUN bash /tmp/install_latex.sh && \
    rm -rf /latex
 
-# Set paths for latex
-ENV PATH=/usr/local/texlive/2022/bin/x86_64-linux:$PATH
-ENV MANPATH=$MANPATH:/usr/local/texlive/2022/texmf-dist/doc/man
-ENV INFOPATH=$INFOPATH:/usr/local/texlive/2022/texmf-dist/doc/info
+# Set paths for latex here and not in install_latex.sh to allow installation of anyfontsize
+ENV PATH=/usr/local/texlive/2023/bin/x86_64-linux:$PATH
+ENV MANPATH=$MANPATH:/usr/local/texlive/2023/texmf-dist/doc/man
+ENV INFOPATH=$INFOPATH:/usr/local/texlive/2023/texmf-dist/doc/info
 
 # install anyfontsize package
 RUN tlmgr install anyfontsize
 
-# Copy in cppcheck
-COPY --from=upstream_cppcheck /usr/bin/cppcheck /usr/local/bin/
-COPY --from=upstream_cppcheck /usr/bin/cppcheck-htmlreport /usr/local/bin/
-COPY --from=upstream_cppcheck /cfg/ /cfg/
-
-# Fix-up for Python3
-RUN sed -e '1 s@python@python3@' -i /usr/local/bin/cppcheck-htmlreport
-
-# Create source, build, and external data directories.
+# Create source, build and external data directories.
 RUN mkdir -p /mantid_src && \
   mkdir -p /mantid_build && \
-  mkdir -p /mantid_data && \
-  mkdir -p /ccache
+  mkdir -p /mantid_data
 
-# Set ccache cache location
-ENV CCACHE_DIR /ccache
-
-# Allow mounting source, build, data and ccache directories
-VOLUME ["/mantid_src", "/mantid_build", "/mantid_data", "/ccache"]
+# Allow mounting source, build and data directories
+VOLUME ["/mantid_src", "/mantid_build", "/mantid_data"]
 
 # Set default working directory to build directory
 WORKDIR /mantid_build

--- a/Linux/development/docker/build_common_slim.sh
+++ b/Linux/development/docker/build_common_slim.sh
@@ -3,6 +3,6 @@
 # Use GitHub packages container registry
 REGISTRY="ghcr.io"
 ORG="mantidproject"
-VERSION="0.14"
+VERSION="0.15"
 
 BUILD_LOG_DIR="build_logs"

--- a/Linux/development/docker/entrypoint.d/010_abc_own_directories.sh
+++ b/Linux/development/docker/entrypoint.d/010_abc_own_directories.sh
@@ -6,4 +6,3 @@ set -x
 chown ${TARGET_USERNAME}:${TARGET_USERNAME} /mantid_src
 chown ${TARGET_USERNAME}:${TARGET_USERNAME} /mantid_build
 chown ${TARGET_USERNAME}:${TARGET_USERNAME} /mantid_data
-chown ${TARGET_USERNAME}:${TARGET_USERNAME} /ccache

--- a/Linux/development/docker/install_latex.sh
+++ b/Linux/development/docker/install_latex.sh
@@ -7,8 +7,3 @@ curl https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz -O -L
 zcat install-tl-unx.tar.gz | tar xf -
 cd install-tl-*
 perl ./install-tl --scheme=medium --no-interaction 
-
-#Set the paths in the bashrc
-echo "export PATH=/usr/local/texlive/2022/bin/x86_64-linux:$PATH" >> /root/.bashrc
-echo "export MANPATH=$MANPATH:/usr/local/texlive/2022/texmf-dist/doc/man" >> /root/.bashrc
-echo "export INFOPATH=$INFOPATH:/usr/local/texlive/2022/texmf-dist/doc/info" >> /root/.bashrc

--- a/Linux/jenkins-node/docker/CentOS7Slim.Dockerfile
+++ b/Linux/jenkins-node/docker/CentOS7Slim.Dockerfile
@@ -1,6 +1,6 @@
 # Arguments allowed to be used in FROM have to come
 # before the first stage
-ARG DEVELOPMENT_IMAGE_VERSION=0.14
+ARG DEVELOPMENT_IMAGE_VERSION=0.15
 FROM ghcr.io/mantidproject/mantid-development-centos7-slim:${DEVELOPMENT_IMAGE_VERSION}
 
 #Add label for transparency

--- a/Linux/jenkins-node/docker/build_common_slim.sh
+++ b/Linux/jenkins-node/docker/build_common_slim.sh
@@ -3,4 +3,4 @@
 # Use GitHub packages container registry
 REGISTRY="ghcr.io"
 ORG="mantidproject"
-VERSION="0.14"
+VERSION="0.15"


### PR DESCRIPTION
The following changes were made:

- Removed ccache (also from 010_abc_own_directories.sh in entrypoint.d)
- Removed cppcheck
- Removed duplicated lines for setting the latex paths from install_latex.sh. These paths have to be set in the docker image directly as otherwise anyfontsize cannot be installed.
- Corrected latex paths from 2022 to 2023
- Moved LABEL command as the first command has to be RUN