### PR TITLE
Create playbook for updating our Linux nodes

### DIFF
--- a/Linux/jenkins-node/ansible/update.yml
+++ b/Linux/jenkins-node/ansible/update.yml
@@ -1,5 +1,4 @@
 ---
 - hosts: all
-  become: yes
   roles:
     - role: dannixon.system.package_updates

--- a/Linux/jenkins-node/ansible/update.yml
+++ b/Linux/jenkins-node/ansible/update.yml
@@ -2,5 +2,9 @@
 - hosts: all
   vars:
     package_updates_reboot: true
+    deploy_type: production
+    jenkins_url: https://builds.mantidproject.org
   roles:
     - role: dannixon.system.package_updates
+    - role: agent
+      become: yes

--- a/Linux/jenkins-node/ansible/update.yml
+++ b/Linux/jenkins-node/ansible/update.yml
@@ -1,4 +1,6 @@
 ---
 - hosts: all
+  vars:
+    package_updates_reboot: true
   roles:
     - role: dannixon.system.package_updates

--- a/Linux/jenkins-node/ansible/update.yml
+++ b/Linux/jenkins-node/ansible/update.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  become: yes
+  roles:
+    - role: dannixon.system.package_updates

--- a/Linux/jenkins-node/readme.md
+++ b/Linux/jenkins-node/readme.md
@@ -61,7 +61,16 @@ ansible-playbook -i inventory.txt jenkins-agent.yml -u SSH_USERNAME -K
 
 - Wait for the play to finish and visit `https://builds.mantidproject.org/computer/NAME_OF_AGENT_ON_JENKINS`. The agent should be connected.
 
-### Maintenance
+## Maintenance
+
+### Updating nodes
+
+To update the packages on our Linux nodes, you can create an `inventory.txt` file with a line for each node, and then run the following
+playbook from the ansible directory:
+
+```sh
+ansible-playbook -i inventory.txt update.yml -u SSH_USERNAME -K
+```
 
 ### Troubleshooting
 


### PR DESCRIPTION
This PR creates an ansible playbook for updating our Linux nodes. It uses a useful role already defined in a Dan Nixon repo.

**To test**
1. ssh into a linux node (not the first linux node as this has already been updated)

```sh
ssh <username>@<node_ip_address>
```

2. Check there is a message that at least 1 package needs updating
3. Exit the machine
4. Create an inventory.txt file in your ansible directory containing the details of this node
5. Run the following playbook
```sh
ansible-playbook -i inventory.txt update.yml -u SSH_USERNAME -K
```
6. ssh back into the linux node. Make sure there are no more updates.

Fixes #87