### PR TITLE
Update Win.Dockerfile following upstream changes

### DIFF
--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -9,7 +9,7 @@ RUN xcopy /y C:\Windows\System32\opengl32.dll C:\GatheredDlls\ && `
 	xcopy /y C:\Windows\System32\MFReadWrite.dll C:\GatheredDlls\ && `
 	xcopy /y C:\Windows\System32\dxva2.dll C:\GatheredDlls\
 
-FROM jenkins/inbound-agent:4.13-2-jdk11-windowsservercore-ltsc2019
+FROM jenkins/inbound-agent:3192.v713e3b_039fb_e-3-jdk11-windowsservercore-ltsc2019
 COPY --from=full C:\GatheredDlls\ C:\Windows\System32\
 
 # Reset the shell.
@@ -28,7 +28,8 @@ RUN powershell New-ItemProperty `
                    -Force
 
 #Install chocolatey
-ENV ChocolateyUseWindowsCompression false 
+ENV ChocolateyUseWindowsCompression false
+ENV chocolateyVersion 1.4.0
 RUN powershell Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force
 RUN powershell -NoProfile -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 RUN powershell Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
@@ -57,7 +58,7 @@ RUN `
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     `
     # Cleanup
-    && del /q vs_buildtools.exe
+    && del /q vs_buildtools.ex
 
 # Start the agent process
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -58,7 +58,7 @@ RUN `
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     `
     # Cleanup
-    && del /q vs_buildtools.ex
+    && del /q vs_buildtools.exe
 
 # Start the agent process
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Jenkins/jenkins-agent.ps1"]


### PR DESCRIPTION
This PR updates the windows dockerfile following various upstream changes that break the image build.

Issues include:

1.  Chocolately installer failing, requiring `.NET Framework 4.8` https://stackoverflow.com/questions/76470752/chocolatey-installation-in-docker-started-to-fail-restart-due-to-net-framework
2. A bug that didn't allow for jenkins direct connections (used for staging nodes): https://github.com/jenkinsci/docker-inbound-agent/issues/358

Please squash the commits on merge.

Confirmed to work on production here: https://builds.mantidproject.org/job/pull_requests-conda-windows/4561/

Image has been uploaded: https://github.com/orgs/mantidproject/packages/container/package/isiscloudwin