### PR TITLE
Internal Staging Node Setup

### DIFF
--- a/Linux/jenkins-node/ansible/jenkins-agent-staging.yml
+++ b/Linux/jenkins-node/ansible/jenkins-agent-staging.yml
@@ -3,8 +3,7 @@
   vars:
     package_updates_reboot: true
     deploy_type: staging
-    jenkins_url: builds.a.staging-mantidproject.org # builds.b.staging-mantidproject.org
-    jenkins_identity: <jenkins_identity>
+    jenkins_url: https://builds.a.staging-mantidproject.stfc.ac.uk # https://builds.b.staging-mantidproject.stfc.ac.uk
     pip_install_packages:
       - name: docker
 

--- a/Linux/jenkins-node/ansible/readme.md
+++ b/Linux/jenkins-node/ansible/readme.md
@@ -12,10 +12,7 @@ jenkins.model.Jenkins.getInstance().getComputer("<jenkins node name>").getJnlpMa
 ```
 - navigate to the [`Ansible folder`](https://github.com/mantidproject/dockerfiles/tree/main/Linux/jenkins-node/ansible)
 - Update the `inventory.txt` file with the IP address, agent name and agent secret (i.e. Jenkins secret code). Be sure to save this file when update complete!
-- If creating staging nodes, update the `jenkins-agent-staging.yml` file to specify the correct `jenkins_url`, and `jenkins_identity` variables. To get the `jenkins_identity` use the following command in the jenkins console: 
-```java
-hudson.remoting.Base64.encode(org.jenkinsci.main.modules.instance_identity.InstanceIdentity.get().getPublic().getEncoded())
-```
+- If creating staging nodes, update the `jenkins-agent-staging.yml` file to specify the correct `jenkins_url` variable. 
 - Run the following command, replacing `staging` with `production` if appropriate and replacing `FedID` with your FedID.
 ```sh
 ansible-playbook -i inventory.txt jenkins-agent-staging.yml -u FedID -K

--- a/Linux/jenkins-node/ansible/roles/agent/tasks/main.yml
+++ b/Linux/jenkins-node/ansible/roles/agent/tasks/main.yml
@@ -35,6 +35,5 @@
     env:
       JENKINS_AGENT_NAME: "{{ agent_name }}"
       JENKINS_SECRET: "{{ agent_secret }}"
-      JENKINS_DIRECT_CONNECTION: "{{ jenkins_url }}:37899"
-      JENKINS_INSTANCE_IDENTITY: "{{ jenkins_identity }}"
+      JENKINS_URL: "{{ jenkins_url }}"
   when: deploy_type == 'staging'


### PR DESCRIPTION
Dockerfiles changes to match:
- https://github.com/mantidproject/ansible-linode/pull/122

Removes the need for the `jenkins_identity` since we're making use of stfc certificates instead. 