### PR TITLE
Java 17 Windows Dockerfile

### DIFF
--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -1,16 +1,16 @@
 # escape=`
 # Use JNLP agent as base and install required tools
-FROM mcr.microsoft.com/windows:10.0.17763.3887-amd64 AS full
+# Use the latest Windows Server Core 2022 image.
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
-RUN xcopy /y C:\Windows\System32\opengl32.dll C:\GatheredDlls\ && `
-	xcopy /y C:\Windows\System32\glu32.dll C:\GatheredDlls\ && `
-	xcopy /y C:\Windows\System32\MF.dll C:\GatheredDlls\ && `
-	xcopy /y C:\Windows\System32\MFPlat.dll C:\GatheredDlls\ && `
-	xcopy /y C:\Windows\System32\MFReadWrite.dll C:\GatheredDlls\ && `
-	xcopy /y C:\Windows\System32\dxva2.dll C:\GatheredDlls\
+#RUN	xcopy /y C:\Windows\System32\glu32.dll C:\GatheredDlls\ && `
+#	xcopy /y C:\Windows\System32\MF.dll C:\GatheredDlls\ && `
+#	xcopy /y C:\Windows\System32\MFPlat.dll C:\GatheredDlls\ && `
+#	xcopy /y C:\Windows\System32\MFReadWrite.dll C:\GatheredDlls\ && `
+#	xcopy /y C:\Windows\System32\dxva2.dll C:\GatheredDlls\
 
 FROM jenkins/inbound-agent:3301.v4363ddcca_4e7-3-jdk17-windowsservercore-ltsc2019
-COPY --from=full C:\GatheredDlls\ C:\Windows\System32\
+#COPY --from=full C:\GatheredDlls\ C:\Windows\System32\
 
 # Reset the shell.
 SHELL ["cmd", "/S", "/C"]
@@ -50,11 +50,10 @@ RUN `
     # Download the Build Tools bootstrapper.
     curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
     `
-    # Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload, excluding workloads and components with known issues.
+    # Install Build Tools with the Microsoft.VisualStudio.Workload.MSBuildTools workload, excluding workloads and components with known issues.
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
-        --add Microsoft.VisualStudio.Workload.AzureBuildTools `
-		--add Microsoft.VisualStudio.Component.VC.CMake.Project `
+        --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended`
         --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
         --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
         --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -50,11 +50,12 @@ RUN `
     # Download the Build Tools bootstrapper.
     curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
     `
-    # Install Build Tools with the Microsoft.VisualStudio.Workload.MSBuildTools workload, excluding workloads and components with known issues.
+    # Install MS Build Tools and MSVC
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
         --add Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64 `
-        --add Microsoft.VisualStudio.Component.Windows10SDK `
+        --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
+        --add Microsoft.VisualStudio.Component.VC.CMake.Project `
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     `
     # Cleanup

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -53,10 +53,10 @@ RUN `
     # Install Build Tools with the Microsoft.VisualStudio.Workload.MSBuildTools workload, excluding workloads and components with known issues.
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
+        --add Microsoft.VisualStudio.ComponentGroup.Tools.VC.143.x86.x64 `
         --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64;14.38.33135 `
         --add Microsoft.VisualStudio.Component.Windows10SDK `
-        --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
-        --add Microsoft.VisualStudio.Component.VC.v142.x86.x64 `
+        --remove Microsoft.VisualStudio.Component.VC.Tools.x86.x64;14.44.35207 `
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     `
     # Cleanup

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -56,6 +56,7 @@ RUN `
         --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64;14.38.33135 `
         --add Microsoft.VisualStudio.Component.Windows10SDK `
         --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
+        --add Microsoft.VisualStudio.Component.VC.v142.x86.x64 `
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     `
     # Cleanup

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -6,7 +6,8 @@ RUN	xcopy /y C:\Windows\System32\glu32.dll C:\GatheredDlls\ && `
 	xcopy /y C:\Windows\System32\MF.dll C:\GatheredDlls\ && `
 	xcopy /y C:\Windows\System32\MFPlat.dll C:\GatheredDlls\ && `
 	xcopy /y C:\Windows\System32\MFReadWrite.dll C:\GatheredDlls\ && `
-	xcopy /y C:\Windows\System32\dxva2.dll C:\GatheredDlls\
+	xcopy /y C:\Windows\System32\dxva2.dll C:\GatheredDlls\ && `
+	xcopy /y C:\Windows\System32\opengl32.dll C:\GatheredDlls\
 
 FROM jenkins/inbound-agent:3301.v4363ddcca_4e7-3-jdk17-windowsservercore-ltsc2019
 COPY --from=full C:\GatheredDlls\ C:\Windows\System32\

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -9,7 +9,7 @@ RUN xcopy /y C:\Windows\System32\opengl32.dll C:\GatheredDlls\ && `
 	xcopy /y C:\Windows\System32\MFReadWrite.dll C:\GatheredDlls\ && `
 	xcopy /y C:\Windows\System32\dxva2.dll C:\GatheredDlls\
 
-FROM jenkins/inbound-agent:3192.v713e3b_039fb_e-3-jdk11-windowsservercore-ltsc2019
+FROM jenkins/inbound-agent:3301.v4363ddcca_4e7-3-jdk17-windowsservercore-ltsc2019
 COPY --from=full C:\GatheredDlls\ C:\Windows\System32\
 
 # Reset the shell.

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -54,6 +54,7 @@ RUN `
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
         --add Microsoft.VisualStudio.Workload.AzureBuildTools `
+		--add Microsoft.VisualStudio.Component.VC.CMake.Project `
         --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
         --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
         --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -53,11 +53,9 @@ RUN `
     # Install Build Tools with the Microsoft.VisualStudio.Workload.MSBuildTools workload, excluding workloads and components with known issues.
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
-        --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended`
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
-        --remove Microsoft.VisualStudio.Component.Windows81SDK `
+        --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64;14.38.33135 `
+        --add Microsoft.VisualStudio.Component.Windows10SDK `
+        --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     `
     # Cleanup

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -1,16 +1,15 @@
 # escape=`
 # Use JNLP agent as base and install required tools
-# Use the latest Windows Server Core 2022 image.
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+FROM mcr.microsoft.com/windows:10.0.17763.7434-amd64 AS full
 
-#RUN	xcopy /y C:\Windows\System32\glu32.dll C:\GatheredDlls\ && `
-#	xcopy /y C:\Windows\System32\MF.dll C:\GatheredDlls\ && `
-#	xcopy /y C:\Windows\System32\MFPlat.dll C:\GatheredDlls\ && `
-#	xcopy /y C:\Windows\System32\MFReadWrite.dll C:\GatheredDlls\ && `
-#	xcopy /y C:\Windows\System32\dxva2.dll C:\GatheredDlls\
+RUN	xcopy /y C:\Windows\System32\glu32.dll C:\GatheredDlls\ && `
+	xcopy /y C:\Windows\System32\MF.dll C:\GatheredDlls\ && `
+	xcopy /y C:\Windows\System32\MFPlat.dll C:\GatheredDlls\ && `
+	xcopy /y C:\Windows\System32\MFReadWrite.dll C:\GatheredDlls\ && `
+	xcopy /y C:\Windows\System32\dxva2.dll C:\GatheredDlls\
 
 FROM jenkins/inbound-agent:3301.v4363ddcca_4e7-3-jdk17-windowsservercore-ltsc2019
-#COPY --from=full C:\GatheredDlls\ C:\Windows\System32\
+COPY --from=full C:\GatheredDlls\ C:\Windows\System32\
 
 # Reset the shell.
 SHELL ["cmd", "/S", "/C"]

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -51,11 +51,12 @@ RUN `
     curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
     `
     # Install MS Build Tools and MSVC
+    # MSVC 14.38.17.8 installed to avoid bug with 14.4*
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
+        --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
         --add Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64 `
         --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
-        --add Microsoft.VisualStudio.Component.VC.CMake.Project `
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     `
     # Cleanup

--- a/Windows/jenkins-node/Win.Dockerfile
+++ b/Windows/jenkins-node/Win.Dockerfile
@@ -53,10 +53,8 @@ RUN `
     # Install Build Tools with the Microsoft.VisualStudio.Workload.MSBuildTools workload, excluding workloads and components with known issues.
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
-        --add Microsoft.VisualStudio.ComponentGroup.Tools.VC.143.x86.x64 `
-        --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64;14.38.33135 `
+        --add Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64 `
         --add Microsoft.VisualStudio.Component.Windows10SDK `
-        --remove Microsoft.VisualStudio.Component.VC.Tools.x86.x64;14.44.35207 `
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     `
     # Cleanup


### PR DESCRIPTION
New docker image for Windows runners that moves us onto Java 17. It also updates the Windows version used in the Docker container, the Visual Studio version and the Build Tools version.