### PR TITLE
update ansible scripts to enable user ssh and new node deployment

### DIFF
--- a/Linux/jenkins-node/ansible/jenkins-agent-production.yml
+++ b/Linux/jenkins-node/ansible/jenkins-agent-production.yml
@@ -1,16 +1,15 @@
 - name: Deploy Docker-based Jenkins agent for Mantid builds
   hosts: all
   vars:
-    package_updates_reboot: true
     deploy_type: production
     jenkins_url: https://builds.mantidproject.org
     pip_install_packages:
       - name: docker
 
   roles:
-    - role: dannixon.system.package_updates
+    - role: setup
       tags: "initial-setup"
-    - role: dannixon.system.interactive_users
+    - role: interactive_users
       tags: "initial-setup"      
     - role: geerlingguy.pip
       become: yes

--- a/Linux/jenkins-node/ansible/jenkins-agent-staging.yml
+++ b/Linux/jenkins-node/ansible/jenkins-agent-staging.yml
@@ -9,9 +9,9 @@
       - name: docker
 
   roles:
-    - role: dannixon.system.package_updates
+    - role: setup
       tags: "initial-setup"
-    - role: dannixon.system.interactive_users
+    - role: interactive_users
       tags: "initial-setup"      
     - role: geerlingguy.pip
       become: yes

--- a/Linux/jenkins-node/ansible/roles/interactive_users/tasks/main.yml
+++ b/Linux/jenkins-node/ansible/roles/interactive_users/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: Configure user
+  ansible.builtin.include_tasks: user.yml
+  loop: "{{ interactive_users }}"
+  loop_control:
+    loop_var: user
+    label: "{{ user.username }}"

--- a/Linux/jenkins-node/ansible/roles/interactive_users/tasks/user.yml
+++ b/Linux/jenkins-node/ansible/roles/interactive_users/tasks/user.yml
@@ -1,0 +1,23 @@
+- name: "Ensure user {{ user.username }} exists"
+  become: true
+  ansible.builtin.user:
+    name: "{{ user.username }}"
+    state: present
+
+- name: "Ensure SSH public key is present for user {{ user.username }}"
+  become: true
+  ansible.posix.authorized_key:
+    user: "{{ user.username }}"
+    key: "{{ user.ssh_pubkey }}"
+    state: present
+  when: user.ssh_pubkey | default(false)
+
+- name: "Add user {{ user.username }} as sudoer"
+  become: true
+  community.general.sudoers:
+    commands: ALL
+    name: "{{ user.username }}"
+    user: "{{ user.username }}"
+    state: "{{ 'present' if user.sudoer | default(false) else 'absent' }}"
+    nopassword: true
+

--- a/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml
+++ b/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: remove repository from sources list that gives error on update
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/repository_egi_eu_sw_production_cas_1_current.list
+    state: absent
+
+- name: Ensure apt packages are up to date
+  become: true
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: "yes"
+  register: updates
+
+- name: Check if reboot is required
+  stat:
+    path: /var/run/reboot-required
+  register: package_updates_reboot
+
+- name: Ensure system is rebooted
+  ansible.builtin.reboot:
+    msg: Rebooting post package update (via Ansible)
+  become: true
+  when: updates.changed and package_updates_reboot
+

--- a/Linux/jenkins-node/scripts/openstack-vm.sh
+++ b/Linux/jenkins-node/scripts/openstack-vm.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Control server(s) on an Openstack cloud.
+# The openstack command must be available on the PATH.
+#
+# This script assumes a ~/.config/openstack/clouds.yaml
+# exists containing credentials for the project that
+# contains the servers. This can be created and downloaded
+# from the Identity->Appplication Credentials section of the
+# OpenStack UI.
+
+# cloudname as in ~/.config/openstack/clouds/yaml
+CLOUDNAME=openstack
+# Server details
+IMAGE=ubuntu-jammy-22.04-nogui
+FLAVOUR=l6.c32
+SECGROUP=default
+KEYNAME= # Key pair name from openstack
+INSTANCENAME_PREFIX=isis-cloud-linux-b
+INSTANCECOUNT=10
+NETWORK=Internal
+
+# Functions
+function up() {
+  openstack \
+    --os-cloud $CLOUDNAME \
+    server create \
+    --image $IMAGE \
+    --flavor $FLAVOUR \
+    --security-group $SECGROUP \
+    --key-name $KEYNAME \
+    --min $INSTANCECOUNT \
+    --max $INSTANCECOUNT \
+    --network $NETWORK \
+    $INSTANCENAME_PREFIX
+  echo "Note: The default openstack output above shows only a single instance even if more were requested."
+  sleep 2
+  echo "Full instance list:"
+  openstack \
+    --os-cloud $CLOUDNAME \
+    server list
+}
+
+function down() {
+  for i in `seq $INSTANCECOUNT`;
+  do
+    openstack \
+      --os-cloud $CLOUDNAME \
+      server delete $INSTANCENAME_PREFIX-$i;
+  done  
+}
+
+function fatal() {
+  >&2 echo $1
+  exit 1
+}
+
+# is openstack command available?
+if ! command -v "openstack" &> /dev/null; then
+  fatal "openstack command not available. Have you activated the environment?"
+fi
+
+case $1 in
+  up) up
+    ;;
+  down) down
+    ;;
+  *)
+    echo Unknown command $1. Use 'up' or 'down'.
+esac
+


### PR DESCRIPTION
This PR:
- Removes a repo from apt sources list that is currently causing an error to be thrown
- Brings Dan's ansible roles into our repo.
- Make changes to said role to use community sudoers module
- Add Martyn's openstack script to repo, add network arg
- Sets use of sudo to `nopassword: true` - given ssh access is protecte by ssh keys I don't think this is necessary. It's also not as easy to do as it used to be, given changed made to openstack by the cloud team. We would have to implement something using a remote password store.

Fixes #117 