### PR TITLE
Update Jenkins agent docker image to the latest version

### DIFF
--- a/Linux/jenkins-node/docker/Alma9.Dockerfile
+++ b/Linux/jenkins-node/docker/Alma9.Dockerfile
@@ -12,7 +12,7 @@ RUN yum install -y \
   rm -rf /tmp/* /var/tmp/*
 
 # Setup Jenkins agent
-ARG JENKINS_AGENT_VERSION=4.14
+ARG JENKINS_AGENT_VERSION=3327.v868139a_d00e0
 RUN export DOCKER_BUILDKIT=1 && \
   mkdir -p /jenkins_workdir && \
   chmod o+rw /jenkins_workdir && \

--- a/Linux/jenkins-node/docker/build_common.sh
+++ b/Linux/jenkins-node/docker/build_common.sh
@@ -3,4 +3,4 @@
 # Use GitHub packages container registry
 REGISTRY="ghcr.io"
 ORG="mantidproject"
-VERSION="0.1"
+VERSION="0.2"


### PR DESCRIPTION
This PR update the Linux Jenkins agent Docker image to the latest version. The image has been updated and uploaded to the GitHub registry as part of the Jenkins maintenance. The new package is now up and labeled with 0.2 version https://github.com/mantidproject/dockerfiles/pkgs/container/jenkins-node-alma9