### PR TITLE
Add Ansible Script to Allow Nodes to Keep Their Own External Data Up-to-date

### DIFF
--- a/Linux/external-data-mirror/ansible/roles/mirror-data/tasks/main.yml
+++ b/Linux/external-data-mirror/ansible/roles/mirror-data/tasks/main.yml
@@ -14,7 +14,7 @@
   when: connected.stdout != "success"
 
 - name: Mirror the external data from the main server in a volume (this may take a while).
-  ansible.builtin.command: "rsync -az --perms -o -g {{ main_server_hostname }}:/srv/{{ main_data_srv_dir }}/ftp/external-data/MD5/ /external-data/MD5/"
+  ansible.builtin.command: "rsync -azvW --perms -o -g {{ main_server_hostname }}:/srv/{{ main_data_srv_dir }}/ftp/external-data/MD5/ /external-data/MD5/"
 
 - name: Copy the data update script onto the mirror machine.
   ansible.builtin.copy:

--- a/Linux/external-data-mirror/ansible/roles/mirror-data/tasks/update-external-data.sh
+++ b/Linux/external-data-mirror/ansible/roles/mirror-data/tasks/update-external-data.sh
@@ -9,7 +9,7 @@ printf "%(%H:%M:%S)T "
 
 if [ -z "${RSYNC_PROCESS_IDS}" ]; then
         echo "running rsync..."
-        rsync -az --perms -o -g  $SERVER_IP:/srv/$FTP_SRV_DIR/ftp/external-data/MD5/ /external-data/MD5/
+        rsync -azvW --perms -o -g  $SERVER_IP:/srv/$FTP_SRV_DIR/ftp/external-data/MD5/ /external-data/MD5/
 else
         echo "rsync is already running. Skipping this time..."
 fi

--- a/Linux/jenkins-node/ansible/jenkins-agent-production.yml
+++ b/Linux/jenkins-node/ansible/jenkins-agent-production.yml
@@ -3,6 +3,7 @@
   vars:
     deploy_type: production
     jenkins_url: https://builds.mantidproject.org
+    data_server_hostname: 130.246.80.136
     pip_install_packages:
       - name: docker
 
@@ -16,7 +17,10 @@
       tags: "initial-setup"      
     - role: geerlingguy.docker
       become: yes
-      tags: "initial-setup"      
+      tags: "initial-setup"     
+    - role: mirror-data  # ONLY WORKS FOR ISIS NODES
+      become: yes
+      tags: ["mirror", never]
     - role: agent
       become: yes
       tags: "agent"

--- a/Linux/jenkins-node/ansible/jenkins-agent-production.yml
+++ b/Linux/jenkins-node/ansible/jenkins-agent-production.yml
@@ -3,7 +3,7 @@
   vars:
     deploy_type: production
     jenkins_url: https://builds.mantidproject.org
-    data_server_hostname: 130.246.80.136
+    data_server_hostname: 172.16.114.127
     pip_install_packages:
       - name: docker
 

--- a/Linux/jenkins-node/ansible/jenkins-agent-production.yml
+++ b/Linux/jenkins-node/ansible/jenkins-agent-production.yml
@@ -11,13 +11,13 @@
     - role: setup
       tags: "initial-setup"
     - role: interactive_users
-      tags: "initial-setup"      
+      tags: "initial-setup"
     - role: geerlingguy.pip
       become: yes
-      tags: "initial-setup"      
+      tags: "initial-setup"
     - role: geerlingguy.docker
       become: yes
-      tags: "initial-setup"     
+      tags: "initial-setup"
     - role: mirror-data  # ONLY WORKS FOR ISIS NODES
       become: yes
       tags: ["mirror", never]

--- a/Linux/jenkins-node/ansible/roles/agent/tasks/main.yml
+++ b/Linux/jenkins-node/ansible/roles/agent/tasks/main.yml
@@ -9,9 +9,9 @@
     pull: yes
     shm_size: 512M
     volumes:
-      - "{{ agent_name }}:/jenkins_workdir"
-      - "{{ agent_name }}_ccache:/ccache"
-      - "{{ agent_name }}_external_data:/mantid_data"
+      - "/{{ agent_name }}/:/jenkins_workdir"
+      - "/{{ agent_name }}_ccache/:/ccache"
+      - "/{{ agent_name }}_external_data/:/mantid_data"
     env:
       JENKINS_AGENT_NAME: "{{ agent_name }}"
       JENKINS_SECRET: "{{ agent_secret }}"
@@ -29,9 +29,9 @@
     pull: yes
     shm_size: 512M
     volumes:
-      - "{{ agent_name }}:/jenkins_workdir"
-      - "{{ agent_name }}_ccache:/ccache"
-      - "{{ agent_name }}_external_data:/mantid_data"
+      - "/{{ agent_name }}/:/jenkins_workdir"
+      - "/{{ agent_name }}_ccache/:/ccache"
+      - "/{{ agent_name }}_external_data/:/mantid_data"
     env:
       JENKINS_AGENT_NAME: "{{ agent_name }}"
       JENKINS_SECRET: "{{ agent_secret }}"

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/exchange-keys.yml
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/exchange-keys.yml
@@ -1,0 +1,44 @@
+- name: Generate key pair if it does not exist
+  community.crypto.openssh_keypair:
+    force: no # Don't regenerate existing keys.
+    path: ~/.ssh/id_rsa
+
+- name: Read public key into tmp to copy over.
+  fetch:
+    src: ~/.ssh/id_rsa.pub
+    dest: /tmp/{{ ansible_hostname }}-id_rsa.pub
+    flat: yes
+
+- name: Add public key to ISIS mirror's authorized keys
+  ansible.posix.authorized_key:
+    user: ubuntu
+    key: "{{ lookup('file','/tmp/{{ ansible_hostname }}-id_rsa.pub')}}"
+  remote_user: ubuntu
+  delegate_to: "{{ data_server_hostname }}"
+
+- name: Touch the known_hosts file if it's missing
+  file:
+    path: ~/.ssh/known_hosts
+    state: touch
+    mode: 0644
+
+- name: Check if known_hosts contains existing server fingerprint
+  command: ssh-keygen -F {{ data_server_hostname }}
+  register: key_exists
+  failed_when: key_exists.stderr != ''
+  changed_when: False
+
+- name: Scan for existing remote ssh fingerprint
+  command: ssh-keyscan -T5 {{ data_server_hostname }}
+  register: keyscan
+  failed_when: keyscan.rc != 0 or keyscan.stdout == ''
+  changed_when: False
+  when: key_exists.rc == 1
+
+- name: Copy ssh-key to local known_hosts
+  lineinfile:
+    name: ~/.ssh/known_hosts
+    create: yes
+    line: "{{ item }}"
+  when: key_exists.rc == 1
+  with_items: "{{ keyscan.stdout_lines|default([]) }}"

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/exchange-keys.yml
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/exchange-keys.yml
@@ -11,7 +11,7 @@
 
 - name: Add public key to ISIS mirror's authorized keys
   ansible.posix.authorized_key:
-    user: mkq48465
+    user: "{{ ansible_user_id }}"
     key: "{{ lookup('file','/tmp/{{ ansible_hostname }}-id_rsa.pub')}}"
   remote_user: ubuntu
   delegate_to: "{{ data_server_hostname }}"

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/exchange-keys.yml
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/exchange-keys.yml
@@ -11,10 +11,11 @@
 
 - name: Add public key to ISIS mirror's authorized keys
   ansible.posix.authorized_key:
-    user: ubuntu
+    user: mkq48465
     key: "{{ lookup('file','/tmp/{{ ansible_hostname }}-id_rsa.pub')}}"
   remote_user: ubuntu
   delegate_to: "{{ data_server_hostname }}"
+  delegate_facts: true
 
 - name: Touch the known_hosts file if it's missing
   file:

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/main.yml
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/main.yml
@@ -1,11 +1,11 @@
 - name: Create a directory to hold the mirror of the external data.
   ansible.builtin.file:
-    path: /external-data/MD5/
+    path: /mantid_data/MD5/
     state: directory
     mode: '0755'
 
 - name: Check if machine has SSH access to the ISIS data store.
-  ansible.builtin.command: ssh -o BatchMode=True ubuntu@{{ data_server_hostname }} 'echo success'
+  ansible.builtin.command: ssh -o BatchMode=True mkq48465@{{ data_server_hostname }} 'echo success'
   register: connected
   ignore_errors: True
 
@@ -14,7 +14,7 @@
   when: connected.stdout != "success"
 
 - name: Mirror the external data from the main server in a volume (this may take a while).
-  ansible.builtin.command: "rsync -az --perms -o -g {{ data_server_hostname }}:/external-data/MD5/ /external-data/MD5/"
+  ansible.builtin.command: "rsync -az --perms -o -g mkq48465@{{ data_server_hostname }}:/external-data/MD5/ /mantid_data/MD5 -v"
 
 - name: Copy the data update script onto the mirror machine.
   ansible.builtin.copy:

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/main.yml
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/main.yml
@@ -1,11 +1,11 @@
 - name: Create a directory to hold the mirror of the external data.
   ansible.builtin.file:
-    path: /mantid_data/MD5/
+    path: /{{ agent_name }}_external_data/MD5/
     state: directory
     mode: '0755'
 
 - name: Check if machine has SSH access to the ISIS data store.
-  ansible.builtin.command: ssh -o BatchMode=True mkq48465@{{ data_server_hostname }} 'echo success'
+  ansible.builtin.command: ssh -o BatchMode=True {{ ansible_user_id }}@{{ data_server_hostname }} 'echo success'
   register: connected
   ignore_errors: True
 
@@ -14,16 +14,16 @@
   when: connected.stdout != "success"
 
 - name: Mirror the external data from the main server in a volume (this may take a while).
-  ansible.builtin.command: "rsync -az --perms -o -g mkq48465@{{ data_server_hostname }}:/external-data/MD5/ /mantid_data/MD5 -v"
+  ansible.builtin.command: "rsync -azvW --perms -o -g {{ ansible_user_id }}@{{ data_server_hostname }}:/external-data/MD5/ /{{ agent_name }}_external_data/MD5 -v"
 
 - name: Copy the data update script onto the mirror machine.
   ansible.builtin.copy:
     src: ./update-external-data.sh
-    dest: /external-data/update-external-data.sh
+    dest: /{{ agent_name }}_external_data/update-external-data.sh
     mode: '0755'
 
 - name: Create a crontab job that runs periodically to keep the data up to date.
   ansible.builtin.cron:
     name: Update external data
     minute: "*/5"
-    job: /external-data/update-external-data.sh {{ data_server_hostname }} >> /external-data/update-log.txt 2>&1
+    job: /{{ agent_name }}_external_data/update-external-data.sh {{ data_server_hostname }} {{ agent_name }} {{ ansible_user_id }} >> /{{ agent_name }}_external_data/update-log.txt 2>&1

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/main.yml
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/main.yml
@@ -1,0 +1,29 @@
+- name: Create a directory to hold the mirror of the external data.
+  ansible.builtin.file:
+    path: /external-data/MD5/
+    state: directory
+    mode: '0755'
+
+- name: Check if machine has SSH access to the ISIS data store.
+  ansible.builtin.command: ssh -o BatchMode=True ubuntu@{{ data_server_hostname }} 'echo success'
+  register: connected
+  ignore_errors: True
+
+- name: Exchange SSH keys with linode so we can access the data.
+  import_tasks: exchange-keys.yml
+  when: connected.stdout != "success"
+
+- name: Mirror the external data from the main server in a volume (this may take a while).
+  ansible.builtin.command: "rsync -az --perms -o -g {{ data_server_hostname }}:/external-data/MD5/ /external-data/MD5/"
+
+- name: Copy the data update script onto the mirror machine.
+  ansible.builtin.copy:
+    src: ./update-external-data.sh
+    dest: /external-data/update-external-data.sh
+    mode: '0755'
+
+- name: Create a crontab job that runs periodically to keep the data up to date.
+  ansible.builtin.cron:
+    name: Update external data
+    minute: "*/5"
+    job: /external-data/update-external-data.sh {{ data_server_hostname }} >> /external-data/update-log.txt 2>&1

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/update-external-data.sh
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/update-external-data.sh
@@ -8,7 +8,7 @@ printf "%(%H:%M:%S)T "
 
 if [ -z "${RSYNC_PROCESS_IDS}" ]; then
         echo "running rsync..."
-        rsync -az --perms -o -g  $SERVER_IP:/external-data/MD5/ /external-data/MD5/
+        rsync -az --perms -o -g  mkq48465@$SERVER_IP:/external-data/MD5/ /mantid_data/MD5/
 else
         echo "rsync is already running. Skipping this time..."
 fi

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/update-external-data.sh
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/update-external-data.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 
 SERVER_IP=${1}
+HOST_NAME=${2}
+USER_NAME=${3}
 
 RSYNC_PROCESS_IDS=$(pidof rsync)
 
@@ -8,7 +10,7 @@ printf "%(%H:%M:%S)T "
 
 if [ -z "${RSYNC_PROCESS_IDS}" ]; then
         echo "running rsync..."
-        rsync -az --perms -o -g  mkq48465@$SERVER_IP:/external-data/MD5/ /mantid_data/MD5/
+        rsync -azvW --perms -o -g  $USER_NAME@$SERVER_IP:/external-data/MD5/ /${HOST_NAME}_external_data/MD5/
 else
         echo "rsync is already running. Skipping this time..."
 fi

--- a/Linux/jenkins-node/ansible/roles/mirror-data/tasks/update-external-data.sh
+++ b/Linux/jenkins-node/ansible/roles/mirror-data/tasks/update-external-data.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+SERVER_IP=${1}
+
+RSYNC_PROCESS_IDS=$(pidof rsync)
+
+printf "%(%H:%M:%S)T "
+
+if [ -z "${RSYNC_PROCESS_IDS}" ]; then
+        echo "running rsync..."
+        rsync -az --perms -o -g  $SERVER_IP:/external-data/MD5/ /external-data/MD5/
+else
+        echo "rsync is already running. Skipping this time..."
+fi


### PR DESCRIPTION
Adds a new role (that is, by default, set to run `never` in the playbook) to the agent playbook that downloads and then sets up a crontab job to keep the external data store up-to-date. This stops nodes having to wait until a build runs on them to download the data, improving parallelization. 

The changes also adjust the way the data is stored on the host machine, moving it from a docker volume (which is inaccessible from the host machine) to a mount in the root directory. This allows viewing and manipulation of the contents of the volume to be performed without having to enter into a docker container.

This change was implemented primarily to get around a bug in a packaging script where new data could not be downloaded.
Having the data present on the machine ahead of time was an easier solution. 

## To Test
- Take a linux node offline.
- SSH into the node. Remove some data from the `/{agent_name}_external_data/MD5` directory.
- Wait a while.
- Check that the crontab job downloaded the missing files by checking `update_log.txt`
- Remove the crontab job (`sudo crontab -e -u root`)
- Run the ansible script 
  `ansible-playbook -i inventory.txt jenkins-agent-production.yml -t "mirror, agent" -u {fedID}`
- SSH back into the machine and check the crontab job is present and the data has been downloaded.