### PR TITLE
include jq and file util

### DIFF
--- a/Linux/development/docker/Alma9.Dockerfile
+++ b/Linux/development/docker/Alma9.Dockerfile
@@ -24,6 +24,7 @@ RUN yum install -y \
   wget \
   which \
   jq \
+  file \
   xorg-x11-server-Xvfb && \
   # Clean up
   rm -rf /tmp/* /var/tmp/* 


### PR DESCRIPTION
To simplify getting information from the json result in [mantid#40114](https://github.com/mantidproject/mantid/pull/40114). Add the tool to the base docker image for linux.

[jq](https://jqlang.org/) is a ubiquitous tool needed for parsing / reducing json. It's usually included by default on all modern Linux distros

file is usually included by default and is needed for coverity scanning tool