### PR TITLE
Add dependabot for updating github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Workflow files stored in the default location of `.github/workflows`
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Since there are now github-actions, configure dependabot to open PRs to update their versions. The contents of this file are copied from mantidproject/mantid.