### PR TITLE
Fixed ansible errors when setting up users on a new node

### DIFF
--- a/Linux/jenkins-node/ansible/roles/interactive_users/tasks/user.yml
+++ b/Linux/jenkins-node/ansible/roles/interactive_users/tasks/user.yml
@@ -10,7 +10,7 @@
     user: "{{ user.username }}"
     key: "{{ user.ssh_pubkey }}"
     state: present
-  when: user.ssh_pubkey | default(false)
+  when: user.ssh_pubkey is defined and user.ssh_pubkey != "" | default(false)
 
 - name: "Add user {{ user.username }} as sudoer"
   become: true

--- a/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml
+++ b/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml
@@ -20,5 +20,5 @@
   ansible.builtin.reboot:
     msg: Rebooting post package update (via Ansible)
   become: true
-  when: updates.changed and package_updates_reboot
+  when: updates.changed and package_updates_reboot.stat.exists
 


### PR DESCRIPTION
Newer versions of ansible(≥2.17) give errors when setting up a new node with users and rebooting the system as below mainly due to an error saying `Conditional result (True) was derived from value of type 'dict'` and this PR fixes those errors.

```
TASK [setup : Ensure system is rebooted] ******************************************************************************************************************* [ERROR]: Task failed: Conditional result (True) was derived from value of type 'dict' at '/home/kli94267/dockerfiles/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml:23:9'. Conditionals must have a boolean result. 

Task failed. 
Origin: /home/kli94267/dockerfiles/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml:19:3 
17 register: package_updates_reboot 
18 
19 - name: Ensure system is rebooted 
^ column 3 
<<< caused by >>>
 Conditional result (True) was derived from value of type 'dict' at '/home/kli94267/dockerfiles/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml:23:9'. Conditionals must have a boolean result. 

Origin: /home/kli94267/dockerfiles/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml:23:9 
21 msg: Rebooting post package update (via Ansible) 
22 become: true 
23 when: updates.changed and package_updates_reboot ^ column 9 
Broken conditionals can be temporarily allowed with the ALLOW_BROKEN_CONDITIONALS configuration option. 
fatal: [172.16.110.47]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (True) was derived from value of type 'dict' at '/home/kli94267/dockerfiles/Linux/jenkins-node/ansible/roles/setup/tasks/main.yml:23:9'. 
Conditionals must have a boolean result."}
```

To test:
1. Spin up a new jenkins node in Open Stack(ex: delete the existing one for staging A-[isis-cloud-linux-staging-1](https://openstack.stfc.ac.uk/project/instances/73d8361d-dfc0-4e19-8703-8d2e84965891/) and recreate )
2. Run the playbook to setup a new node as given [here](https://github.com/mantidproject/dockerfiles/tree/main/Linux/jenkins-node/ansible#setting-up-cloud-nodes): 
```
ansible-playbook -i inventory.txt jenkins-agent-staging.yml -u FedID -K
```
3. Playbook should run successfully without giving the above errors
