### PR TITLE
doctest cleanup tag introduced to cleanup script

### DIFF
--- a/Linux/jenkins-node/ansible/clean-jenkins-agents.yml
+++ b/Linux/jenkins-node/ansible/clean-jenkins-agents.yml
@@ -1,7 +1,7 @@
 - name: Playbook to clean jenkins agents by removing workspaces.
   hosts: all
 
-  # Tags available: pr, nightly, package, docs
+  # Tags available: pr, nightly, package, docs, doctest
   tasks:
   - name: Collect workspace sizes
     community.docker.docker_container_exec:
@@ -48,6 +48,14 @@
       chdir: "/jenkins_workdir/workspace"
     become: yes
     tags: [never, docs]
+  
+  - name: Remove Doc test directories
+    community.docker.docker_container_exec:
+      container: "{{ agent_name }}"
+      command: bash -l -c "rm -rf pull_requests-doc-tests*"
+      chdir: "/jenkins_workdir/workspace"
+    become: yes
+    tags: [never, doctest]
 
   - name: Remove Core Pipeline directories
     community.docker.docker_container_exec:

--- a/Linux/jenkins-node/ansible/readme.md
+++ b/Linux/jenkins-node/ansible/readme.md
@@ -69,11 +69,12 @@ ansible-playbook -i inventory.txt jenkins-agent-staging.yml -u FedID -K -t agent
   - `package`: Build Packages from Branch.
   - `docs`: Docs build and publish.
   - `core`: Core Team test pipeline builds.
+  - `doctest`: Doc test builds.
 
 - Run the following with the desired tags (which use a comma-separated list):
 
   ```sh
-  ansible-playbook -i inventory.txt clean-jenkins-agents.yml -u FedID -K -t pr,nightly,package,docs,core
+  ansible-playbook -i inventory.txt clean-jenkins-agents.yml -u FedID -K -t pr,nightly,package,docs,core,doctest
   ```
 
 - Set the nodes you shut down back online.


### PR DESCRIPTION
It has been noted that currently there is no tag related to cleaning `/jenkins_workdir/workspace/pull_requests-doc-tests` path in the jenkins nodes when it's needed to clean doc test jenkins workflows.

This PR introduced a new ansible tag `doctest` for that task that can be used with the [nodes cleanup script](https://github.com/mantidproject/dockerfiles/tree/main/Linux/jenkins-node/ansible#cleaning-nodes).

To test:
1. take a linux node that has recently built [doc test](https://builds.mantidproject.org/view/Pull%20Requests/job/pull_requests-doc-tests/) pipeline offline 
2. run below script to remove `pull_requests-doc-tests` dir associated with doc test inside the jenkins workspace.

```
ansible-playbook -i inventory.txt clean-jenkins-agents.yml -u FedID -K -t doctest
```
